### PR TITLE
Documentation Update: change: watcher-name (PR #22)

### DIFF
--- a/configuration/config-changes-pr-22.md
+++ b/configuration/config-changes-pr-22.md
@@ -1,0 +1,48 @@
+# Configuration Documentation
+
+## PR Title: change: watcher-name
+
+This PR introduces a change in the watcher name used in the development process, specifically when working with the Storefront. The watcher name has been changed from `watch:storefront` to `watch:frontend`.
+
+## File Changes
+
+The change has been made in the `composer.json` file:
+
+```diff
+- "watch:storefront": "..."
++ "watch:frontend": "..."
+```
+
+## Configuration Changes
+
+### New/Modified Configuration Options
+
+The `watch:storefront` script has been renamed to `watch:frontend`. This change affects the development process, specifically when working with the Storefront.
+
+### Environment Variable Changes
+
+No environment variable changes were introduced in this PR.
+
+### Default Value Changes
+
+No default value changes were introduced in this PR.
+
+### Migration Steps for Existing Configurations
+
+Developers who have been using the `watch:storefront` script should now use the `watch:frontend` script. No other changes are required.
+
+### Examples of New Configuration Formats
+
+To start the watcher for the Storefront, use the following command:
+
+```bash
+composer run watch:frontend
+```
+
+## Impact
+
+This change is relatively minor but important for developers to note. There is no apparent impact on the end-users or the functionality of the application.
+
+## Recommendations
+
+Update any developer documentation or guides that reference the `watch:storefront` script to reflect the new `watch:frontend` script.


### PR DESCRIPTION
# Documentation Update for PR #22

This PR updates documentation based on changes from [PR #22](https://github.com/Isengo1989/platform/pull/22) in the source repository.

## 📊 Change Analysis
- **Impact Score**: 2.5/10
- **Files Updated**: 1 documentation files
- **Source Changes**: Large-scale modifications detected

## 📝 Documentation Files Updated
- `configuration/config-changes-pr-22.md`

## 🎯 Key Areas Addressed
- Update any developer documentation or guides that reference the `watch:storefront` script to reflect the new `watch:frontend` script.

## 📋 Summary
The PR primarily affects the development process, specifically when working with the Storefront. The change is relatively minor but important for developers to note. There is no apparent impact on the end-users or the functionality of the application. No documentation files were found to be directly affected by this PR.

---
*This documentation was automatically generated based on code change analysis.*