### PR TITLE
Documentation Update: change: watcher-name (PR #22)

### DIFF
--- a/configuration/config-changes-pr-22.md
+++ b/configuration/config-changes-pr-22.md
@@ -1,0 +1,39 @@
+# Configuration Documentation
+
+## Change: Watcher Name
+
+This documentation covers the changes made to the watcher name in the `composer.json` file.
+
+### 1. Configuration Options
+
+The watcher name for the Storefront has been changed. The old command `watch:storefront` has been replaced with the new command `watch:frontend`.
+
+### 2. Environment Variable Changes
+
+No environment variable changes were made in this update.
+
+### 3. Default Value Changes
+
+The default command to watch the Storefront has been changed from `watch:storefront` to `watch:frontend`.
+
+### 4. Migration Steps for Existing Configurations
+
+If you have any scripts, automation, or documentation that uses the `watch:storefront` command, you will need to update them to use the new `watch:frontend` command.
+
+### 5. Examples of New Configuration Formats
+
+In your scripts or automation, replace any instance of `watch:storefront` with `watch:frontend`.
+
+Old command:
+```
+composer run watch:storefront
+```
+
+New command:
+```
+composer run watch:frontend
+```
+
+### Important Notes
+
+Please ensure to inform all developers and users about this change in command. This can be done through release notes or documentation updates. All documentation that references the `watch:storefront` command should be updated to reflect the new `watch:frontend` command.


### PR DESCRIPTION
# Documentation Update for PR #22

This PR updates documentation based on changes from [PR #22](https://github.com/Isengo1989/platform/pull/22) in the source repository.

## 📊 Change Analysis
- **Impact Score**: 3.5/10
- **Files Updated**: 1 documentation files
- **Source Changes**: Large-scale modifications detected

## 📝 Documentation Files Updated
- `configuration/config-changes-pr-22.md`

## 🎯 Key Areas Addressed
- Update all documentation that references the 'watch:storefront' command to reflect the new 'watch:frontend' command.
- Inform developers and users about the change in command through release notes or documentation updates.
- Update any scripts or automation that use the 'watch:storefront' command to use the new 'watch:frontend' command.

## 📋 Summary
The PR involves a change in the watcher name for the Storefront in the 'composer.json' file. This change will affect any documentation, scripts, or automation that use the old command. Developers and users will also need to be informed about this change.

---
*This documentation was automatically generated based on code change analysis.*