### PR TITLE
Documentation Update: change: watcher-name (PR #22)

### DIFF
--- a/configuration/config-changes-pr-22.md
+++ b/configuration/config-changes-pr-22.md
@@ -1,0 +1,41 @@
+# Configuration Documentation
+
+## Change: Watcher Name
+
+This documentation covers the changes made to the watcher name in the `composer.json` file. The watcher name has been changed from `watch:storefront` to `watch:frontend`.
+
+### New/Modified/Removed Configuration Options
+
+- **Modified**: The watcher name in the `composer.json` file has been changed. The previous name was `watch:storefront`, and the new name is `watch:frontend`.
+
+### Environment Variable Changes
+
+- No environment variable changes were made in this update.
+
+### Default Value Changes
+
+- The default value for the watcher name has been changed from `watch:storefront` to `watch:frontend`.
+
+### Migration Steps for Existing Configurations
+
+1. Open the `composer.json` file in your project.
+2. Locate the `scripts` section.
+3. Find the `watch:storefront` script.
+4. Change the name of the script from `watch:storefront` to `watch:frontend`.
+5. Save and close the `composer.json` file.
+
+### Examples of New Configuration Formats
+
+In the `composer.json` file, the `scripts` section should now look like this:
+
+```json
+"scripts": {
+    "watch:frontend": "..."
+}
+```
+
+## Important Notes
+
+Please note that this change will affect the setup or deployment process. Developers who use this script for enabling hot module reloading for the Storefront will need to use the new script name, `watch:frontend`.
+
+All references to the `watch:storefront` script in the documentation should be updated to `watch:frontend`.


### PR DESCRIPTION
# Documentation Update for PR #22

This PR updates documentation based on changes from [PR #22](https://github.com/Isengo1989/platform/pull/22) in the source repository.

## 📊 Change Analysis
- **Impact Score**: 3.5/10
- **Files Updated**: 1 documentation files
- **Source Changes**: Large-scale modifications detected

## 📝 Documentation Files Updated
- `configuration/config-changes-pr-22.md`

## 🎯 Key Areas Addressed
- Update the script name from 'watch:storefront' to 'watch:frontend' in the affected documentation files.
- Communicate the change in the script name to the developers who use this script for enabling hot module reloading for the Storefront.
- Ensure that all references to the 'watch:storefront' script in the documentation are updated to 'watch:frontend'.

## 📋 Summary
The PR involves a change in the script name in the `composer.json` file, which affects the setup or deployment process. This change requires updates in the documentation to avoid confusion for developers. The impact score is 3.5, considering the base impact score and the fact that configuration files are affected and related docs show outdated information.

---
*This documentation was automatically generated based on code change analysis.*